### PR TITLE
Loosen the PSR requirements to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "role": "Developer"
     }],
     "require": {
-        "psr/log": "1.0.0",
+        "psr/log": "^1.0",
         "php": "^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
It allows to install it on projects using i.e. Laravel which uses PSR 1.0.2